### PR TITLE
gitignore: add google test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+#######################
+#
+# This file contains the list of patterns which git should ignore
+# while tracking the project, this avoids any useless clutter
+# generated when building the project or by text editors to pollute
+# the source code of the remote repository.
+#
+#######################
+
+
 #############
 ### CMake ###
 #############

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,13 @@
+#######################
+#
+# This file contains the list of patterns which git should ignore
+# while inside the tests subdirectory.
+# These generally contain google test sourcd code ( can be directly
+# installed via cmake ) and other dynamically generated files by
+# google test framework.
+#
+#######################
+
+googletest-build/
+googletest-download/
+googletest-src/


### PR DESCRIPTION
- Add google test source and build files to gitignore
- Add documentation comment on top of all gitignore files