### PR TITLE
Fix: rename built library to cpu.a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 
-project( 8085 )
+project(8085)
 
 # Turn on the ability to create folders to organize projects (.vcproj)
 # It creates "CMakePredefinedTargets" folder by default and adds CMake

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Simply navigate to the repository ( `$ cd 8085` ) and use `cmake` to gneerate bu
 $ cmake . && make
 ```
 
-When done all the the binaries ( currently there are none ) should be present in '/bin' subdirectory and libraries in '/lib' subdirectory ( cmake is currently configured to compile it to a static library.
+When done, the library should be built as 'src/cpu.a' ( cmake is currently configured to compile it to a static library ).
 
 ### without using Cmake
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 
-project(lib8085)
+project(cpu)
 
 if(MSVC)
   add_compile_options(/MP) # Use multiple processors when building
@@ -16,6 +16,6 @@ set(EMULATOR_SOURCES "cpu.h" "cpu.cpp" "main.cpp")
 
 source_group("src" FILES ${EMULATOR_SOURCES})
 
-add_library(lib8085 ${EMULATOR_SOURCES})
+add_library(cpu ${EMULATOR_SOURCES})
 
-target_include_directories (lib8085 PUBLIC "${PROJECT_SOURCE_DIR}")
+target_include_directories (cpu PUBLIC "${PROJECT_SOURCE_DIR}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,6 @@ set(emulator_SOURCES
 source_group("src" FILES ${emulator_SOURCES})
 
 add_executable(emulatorTest ${emulator_SOURCES})
-add_dependencies(emulatorTest lib8085)
+add_dependencies(emulatorTest cpu)
 target_link_libraries(emulatorTest gtest)
-target_link_libraries(emulatorTest lib8085)
+target_link_libraries(emulatorTest cpu)


### PR DESCRIPTION
- Fix some minor formatting erros in cmakelists.txt
- Change the name of the built library to cpu.a
- fix #44 